### PR TITLE
Pad short parameter names before using File.createTempFile

### DIFF
--- a/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterValue.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -72,7 +73,7 @@ abstract class AbstractFileParameterValue extends ParameterValue {
 
     protected FilePath createTempFile(@NonNull Run<?,?> build, @NonNull FilePath tempDir, @NonNull EnvVars env, @NonNull Launcher launcher, @NonNull TaskListener listener) throws IOException, InterruptedException {
         assert Util.isOverridden(AbstractFileParameterValue.class, getClass(), "open", Run.class);
-        FilePath f = tempDir.createTempFile(name, null);
+        FilePath f = tempDir.createTempFile(StringUtils.rightPad(name, 3, 'x'), null);
         try (InputStream is = open(build)) {
             f.copyFrom(is);
         }

--- a/src/test/java/io/jenkins/plugins/file_parameters/FileParameterWrapperTest.java
+++ b/src/test/java/io/jenkins/plugins/file_parameters/FileParameterWrapperTest.java
@@ -208,4 +208,18 @@ public class FileParameterWrapperTest {
         r.assertLogContains("loaded 'UPLOADED CONTENT HERE'", b);
     }
 
+    @Test public void shortParameterName() throws Exception {
+        r.createSlave("remote", null, null);
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.addProperty(new ParametersDefinitionProperty(new Base64FileParameterDefinition("F")));
+        p.setDefinition(new CpsFlowDefinition("node('remote') {withFileParameter('F') {echo(/loaded '${readFile(F).toUpperCase(Locale.ROOT)}' from $F/)}}", true));
+        assertThat(new CLICommandInvoker(r, "build").
+                withStdin(new ByteArrayInputStream("uploaded content here".getBytes())).
+                invokeWithArgs("-f", "-p", "F=", "p"),
+                CLICommandInvoker.Matcher.succeeded());
+        WorkflowRun b = p.getBuildByNumber(1);
+        assertNotNull(b);
+        r.assertLogContains("loaded 'UPLOADED CONTENT HERE' from ", b);
+    }
+
 }


### PR DESCRIPTION
Otherwise can get an error:

```
Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to remote
		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1800)
		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:357)
		at hudson.remoting.Channel.call(Channel.java:1001)
		at hudson.FilePath.act(FilePath.java:1070)
		at hudson.FilePath.act(FilePath.java:1059)
		at hudson.FilePath.createTempFile(FilePath.java:1419)
		at io.jenkins.plugins.file_parameters.AbstractFileParameterValue.createTempFile(AbstractFileParameterValue.java:75)
		at io.jenkins.plugins.file_parameters.FileParameterWrapper.setUp(FileParameterWrapper.java:89)
		at org.jenkinsci.plugins.workflow.steps.CoreWrapperStep$Execution2.doStart(CoreWrapperStep.java:116)
		at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
java.lang.IllegalArgumentException: Prefix string too short
	at java.io.File.createTempFile(File.java:2003)
	at hudson.FilePath$CreateTempFile.invoke(FilePath.java:1434)
	at hudson.FilePath$CreateTempFile.invoke(FilePath.java:1424)
	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3122)
	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
	at hudson.remoting.Request$2.run(Request.java:375)
	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:73)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
