### PR TITLE
Stop using ACI Windows agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+buildPlugin(platforms: ['maven', 'windows'])


### PR DESCRIPTION
`maven-windows` agents have flaked a lot recently. Seems that a test agent does not connect properly? https://github.com/jenkinsci/file-parameters-plugin/pull/43/checks?check_run_id=2364058204 for example. Trying VM-based Windows agents, and may give up on Windows CI entirely if that does not help.
