### PR TITLE
Show that `Base64` can be used in Groovy for simple manipulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Nor can you use the `withFileParameter` wrapper here.
 You can use Base64 parameters for passing _small_ files to downstream builds:
 
 ```groovy
-build job: 'downstream', parameters: [base64File(name: 'file', base64: 'aGVsbG8=')]
+build job: 'downstream', parameters: [base64File(name: 'file', base64: Base64.encoder.encodeToString('hello'.bytes)))]
 ```
 
 ## LICENSE

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1.77-rc1068.93d45dd18835</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/339 -->
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.77-rc1068.93d45dd18835</version> <!-- TODO https://github.com/jenkinsci/script-security-plugin/pull/339 -->
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/src/test/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinitionTest.java
+++ b/src/test/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinitionTest.java
@@ -113,4 +113,16 @@ public class AbstractFileParameterDefinitionTest {
         r.assertLogContains("received null: null", b);
     }
 
+    @Test public void buildStep() throws Exception {
+        WorkflowJob us = r.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition("build job: 'ds', parameters: [base64File(name: 'FILE', base64: Base64.encoder.encodeToString('a message'.bytes))]", true));
+        WorkflowJob ds = r.createProject(WorkflowJob.class, "ds");
+        ds.addProperty(new ParametersDefinitionProperty(new Base64FileParameterDefinition("FILE")));
+        ds.setDefinition(new CpsFlowDefinition("echo(/got ${new String(Base64.decoder.decode(FILE))}/)", true));
+        r.buildAndAssertSuccess(us);
+        WorkflowRun b = ds.getBuildByNumber(1);
+        assertNotNull(b);
+        r.assertLogContains("got a message", b);
+    }
+
 }


### PR DESCRIPTION
Depends on https://github.com/jenkinsci/script-security-plugin/pull/339. Closes #21.
