### PR TITLE
Switching back to `useContainerAgent: true`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,1 @@
-/*
- See the documentation for more options:
- https://github.com/jenkins-infra/pipeline-library/
-*/
-buildPlugin(platforms: ['maven', 'windows'])
+buildPlugin(useContainerAgent: true)


### PR DESCRIPTION
Contra #44. Noticed that #72 is failing due to bogus attempts to use `tool` in a container image. Thought this might be a regression from https://github.com/jenkins-infra/pipeline-library/pull/220 but more likely some unrelated problem.
