### PR TITLE
README.md: Split examples into separate snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,46 @@ See [JENKINS-27413](https://issues.jenkins-ci.org/browse/JENKINS-27413) and [JEN
 
 ## Minimal usage
 
-If you defined a Base64 file parameter named `FILE` in the GUI configuration for a Pipeline project, you can access it in a couple of ways:
+### Base64 file parameter
+
+If you defined a Base64 file parameter named `FILE` in the GUI configuration for a Pipeline project, you can access it in a couple of ways - as a Base64-encoded environment variable:
 
 ```groovy
 node {
     sh 'echo $FILE | base64 -d'
+}
+```
+
+Or via a temporary file with the decoded content:
+
+```
+node {
     withFileParameter('FILE') {
         sh 'cat $FILE'
     }
 }
 ```
 
-That is: as a Base64-encoded environment variable; or via a temporary file with the decoded content.
+### Stashed file parameter
 
-A stashed file parameter can also be accessed in a couple of ways:
+A stashed file parameter can also be accessed in a couple of ways - as a stash of the same name with a single file of the same name:
 
 ```groovy
 node {
     unstash 'FILE'
     sh 'cat FILE'
+}
+```
+
+Or via a temporary file:
+
+```groovy
+node {
     withFileParameter('FILE') {
         sh 'cat $FILE'
     }
 }
 ```
-
-That is: as a stash of the same name with a single file of the same name; or, again, via a temporary file.
 
 ## Accessing original upload filename
 


### PR DESCRIPTION
I found it quite suprising that one single snippet was in fact two examples in one
field - I think splitting them up is a bit more readable.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
