### PR TITLE
Forward compatibility with Commons FileUpload 2.x

### DIFF
--- a/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinition.java
@@ -37,7 +37,6 @@ import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileUploadBase;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -68,8 +67,12 @@ abstract class AbstractFileParameterDefinition extends ParameterDefinition {
             FileItem src;
             try {
                 src = req.getFileItem(getName());
-            } catch (ServletException x) {
-                if (x.getCause() instanceof FileUploadBase.InvalidContentTypeException) {
+            } catch (Exception x) {
+                // TODO simplify when we drop support for Commons FileUpload 1.x
+                String simpleName =
+                        x.getCause() != null ? x.getCause().getClass().getSimpleName() : null;
+                if ("InvalidContentTypeException".equals(simpleName) /* Commons FileUpload 1.x */
+                        || "FileUploadContentTypeException".equals(simpleName)) /* Commons FileUpload 2.x */ {
                     src = null;
                 } else {
                     throw x;


### PR DESCRIPTION
While testing with Jakarta servlet imports and Commons FileUpload 2.x, I got this exception:

```
org.apache.commons.fileupload2.core.FileUploadContentTypeException: the request doesn't contain a multipart/form-data or multipart/mixed stream, content type header is application/x-www-form-urlencoded
        at org.apache.commons.fileupload2.core.FileItemInputIteratorImpl.init(FileItemInputIteratorImpl.java:233)
        at org.apache.commons.fileupload2.core.FileItemInputIteratorImpl.getMultiPartInput(FileItemInputIteratorImpl.java:202)
        at org.apache.commons.fileupload2.core.FileItemInputIteratorImpl.findNextItem(FileItemInputIteratorImpl.java:131)
        at org.apache.commons.fileupload2.core.FileItemInputIteratorImpl.&lt;init>(FileItemInputIteratorImpl.java:114)
        at org.apache.commons.fileupload2.core.AbstractFileUpload.getItemIterator(AbstractFileUpload.java:301)
        at org.apache.commons.fileupload2.core.AbstractFileUpload.parseRequest(AbstractFileUpload.java:464)
        at org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload.parseRequest(JakartaServletFileUpload.java:117)
        at org.kohsuke.stapler.RequestImpl.parseMultipartFormData(RequestImpl.java:1093)
```

The root cause is that in FileUpload 2.x, `FileUploadBase` has been removed and exceptions have been renamed to new top-level classes.

Without dropping support for FileUpload 1.x, this PR adds forward compatibility for FileUpload 2.x by being more flexible with regard to the exception type that is returned. I verified that this chased away the above error when running on Commons FileUpload 2.x.