### PR TITLE
Allow for deeply nested causes

### DIFF
--- a/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinition.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterDefinition.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.plugins.file_parameters;
 
+import com.google.common.base.Throwables;
 import hudson.cli.CLICommand;
 import hudson.model.Failure;
 import hudson.model.ParameterDefinition;
@@ -69,8 +70,7 @@ abstract class AbstractFileParameterDefinition extends ParameterDefinition {
                 src = req.getFileItem(getName());
             } catch (Exception x) {
                 // TODO simplify when we drop support for Commons FileUpload 1.x
-                String simpleName =
-                        x.getCause() != null ? x.getCause().getClass().getSimpleName() : null;
+                String simpleName = Throwables.getRootCause(x).getClass().getSimpleName();
                 if ("InvalidContentTypeException".equals(simpleName) /* Commons FileUpload 1.x */
                         || "FileUploadContentTypeException".equals(simpleName)) /* Commons FileUpload 2.x */ {
                     src = null;


### PR DESCRIPTION
Amends https://github.com/jenkinsci/file-parameters-plugin/pull/176 to work with my latest Jakarta prototype, which wraps the `javax.servlet.ServletException` in one layer of `jakarta.servlet.ServletException` as part of the compatibility code. Rather than attempt to peel back the layers with more null checks, I am simply using a Guava method to get the deepest exception.

### Testing done

`mvn clean verify` now passes on both the default branch and my Jakarta prototype