### PR TITLE
Ensure a stashedFile parameter is retained on a Jenkins restart while in the queue

### DIFF
--- a/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
@@ -56,8 +56,6 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
 
     private final String tmpFile;
 
-    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Doesn't make sense to persist it")
-
     @DataBoundConstructor public StashedFileParameterValue(String name, FileItem file) throws IOException {
         this(name, file.getInputStream());
         setFilename(file.getName());

--- a/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
@@ -38,9 +38,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -53,7 +56,7 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
 
     private static final long serialVersionUID = 1L;
 
-    private final String tmpFile;
+    private String tmpFile;
 
     @DataBoundConstructor public StashedFileParameterValue(String name, FileItem file) throws IOException {
         this(name, file.getInputStream());
@@ -63,7 +66,9 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
 
     StashedFileParameterValue(String name, InputStream src) throws IOException {
         super(name);
-        File tmp = new File(Util.createTempDir(), name);
+        Path dir = Util.createDirectories(Util.fileToPath(new File(Jenkins.get().getRootDir(), "stashedFileParameterValueFiles")));
+        File tmpDir = Files.createTempDirectory(dir, null).toFile();
+        File tmp = new File(tmpDir, name);
         FileUtils.copyInputStreamToFile(src, tmp);
         tmpFile = tmp.getAbsolutePath();
     }
@@ -83,6 +88,7 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
             }
             try {
                 FileUtils.deleteDirectory(tmp.getParentFile());
+                tmpFile = null;
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -66,8 +67,9 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
 
     StashedFileParameterValue(String name, InputStream src) throws IOException {
         super(name);
-        Path dir = Util.createDirectories(Util.fileToPath(new File(Jenkins.get().getRootDir(), "stashedFileParameterValueFiles")));
-        File tmpDir = Files.createTempDirectory(dir, null).toFile();
+        File dir = new File(Jenkins.get().getRootDir(), "stashedFileParameterValueFiles");
+        Files.createDirectories(dir.toPath());
+        File tmpDir = Files.createTempDirectory(dir.toPath(), null).toFile();
         File tmp = new File(tmpDir, name);
         FileUtils.copyInputStreamToFile(src, tmp);
         tmpFile = tmp.getAbsolutePath();

--- a/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
@@ -26,16 +26,22 @@ package io.jenkins.plugins.file_parameters;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
+import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.model.ParametersAction;
+import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.queue.QueueListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
@@ -44,11 +50,14 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class StashedFileParameterValue extends AbstractFileParameterValue {
 
+    private static final Logger LOGGER = Logger.getLogger(StashedFileParameterValue.class.getName());
+
     private static final long serialVersionUID = 1L;
 
+    private final String tmpFile;
+
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Doesn't make sense to persist it")
-    private transient File tmp;
-    
+
     @DataBoundConstructor public StashedFileParameterValue(String name, FileItem file) throws IOException {
         this(name, file.getInputStream());
         setFilename(file.getName());
@@ -57,14 +66,15 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
 
     StashedFileParameterValue(String name, InputStream src) throws IOException {
         super(name);
-        tmp = new File(Util.createTempDir(), name);
-        tmp.deleteOnExit();
+        File tmp = new File(Util.createTempDir(), name);
         FileUtils.copyInputStreamToFile(src, tmp);
+        tmpFile = tmp.getAbsolutePath();
     }
 
     @Override public void buildEnvironment(Run<?, ?> build, EnvVars env) {
         super.buildEnvironment(build, env);
-        if (tmp != null) {
+        File tmp = tmpFile != null ? new File(tmpFile) : null;
+        if (tmp != null && tmp.isFile()) {
             try {
                 FlowExecutionOwner feo = build instanceof FlowExecutionOwner.Executable ? ((FlowExecutionOwner.Executable) build).asFlowExecutionOwner() : null;
                 TaskListener listener = feo != null ? feo.getListener() : TaskListener.NULL;
@@ -75,8 +85,7 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
                 throw new RuntimeException( x );
             }
             try {
-                Files.deleteIfExists(tmp.toPath());
-                tmp = null;
+                FileUtils.deleteDirectory(tmp.getParentFile());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -88,4 +97,30 @@ public final class StashedFileParameterValue extends AbstractFileParameterValue 
         return tempDir.child(name);
     }
 
+    @Extension
+    public static class CancelledQueueListener extends QueueListener {
+
+        @Override
+        public void onLeft(Queue.LeftItem li) {
+            if (li.isCancelled()) {
+                List<ParametersAction> actions = li.getActions(ParametersAction.class);
+                actions.forEach(a -> {
+                    a.getAllParameters().stream()
+                            .filter(p -> p instanceof StashedFileParameterValue)
+                            .map(p -> (StashedFileParameterValue) p)
+                            .forEach(p -> {
+                                if (p.tmpFile != null) {
+                                    File tmp = new File(p.tmpFile);
+                                    try {
+                                        FileUtils.deleteDirectory(tmp.getParentFile());
+                                    } catch (IOException | IllegalArgumentException e) {
+                                        LOGGER.log(Level.WARNING, "Unable to delete temporary file {0} for parameter {1} of task {2}",
+                                                new Object[]{tmp.getAbsolutePath(), p.getName(), li.task.getName()});
+                                    }
+                                }
+                            });
+                });
+            }
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/StashedFileParameterValue.java
@@ -24,7 +24,6 @@
 
 package io.jenkins.plugins.file_parameters;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;


### PR DESCRIPTION
Previously the temporary file was deleted when the job was waiting in the queue and Jenkins was restarted.

fixes #254 

<!-- Please describe your pull request here. -->

### Testing done
Added a unit test which fails without this fix.
Manually verified that the temporary folder with the file is deleted when cancelling the entry from the queue

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
