### PR TITLE
do not restrict the original filename

### DIFF
--- a/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/file_parameters/AbstractFileParameterValue.java
@@ -34,6 +34,7 @@ import hudson.model.Failure;
 import hudson.model.ParameterValue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import java.io.File;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,14 +60,9 @@ public abstract class AbstractFileParameterValue extends ParameterValue {
     }
 
     final void setFilename(String filename) {
-        try {
-            Jenkins.checkGoodName(filename);
-            this.filename = filename;
-        } catch (Failure x) {
-            // Ignore and leave the filename undefined.
-            // FileItem.getName Javadoc claims Opera might pass a full path.
-            // This is a best effort anyway (scripts should be written to tolerate an undefined name).
-        }
+        // FileItem.getName Javadoc claims Opera might pass a full path, so strip to just the name.
+        // This is a best effort anyway (scripts should be written to tolerate an undefined name).
+        this.filename = new File(filename).getName();
     }
 
     protected InputStream open(@CheckForNull Run<?,?> build) throws IOException, InterruptedException {


### PR DESCRIPTION
There is no reason to not allow any character here that is allowed in the file system. This is only used to set the value of an environment variable. Ensure that only the filename is used and not a potential full path (see comment about Opera)

fixes #247 
<!-- Please describe your pull request here. -->

### Testing done
Created a file that contains a `!` in the name, verified that the env variable `<parameterName>_FILENAME` is properly set.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
